### PR TITLE
avxjudge.py: fix run with report

### DIFF
--- a/avxjudge.py
+++ b/avxjudge.py
@@ -126,13 +126,12 @@ def is_avx512(instruction:str, args:str) -> float:
     return val
 
 
+def ratio(f: float) -> str:
+    f = f * 100
+    f = round(f)/100.0
+    return str(f)
+
 def print_top_functions() -> None:
-    def ratio(f: float) -> str:
-        f = f * 100
-        f = round(f)/100.0
-        return str(f)
-
-
     def summarize(table: dict, is_pct: bool, max_funcs: int = 5) -> None:
         for f in sorted(table, key=table.get, reverse=True)[:max_funcs]:
             f = "    %-30s\t%s" % (f, ratio(table[f]))


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/avxjudge.py", line 344, in <module>
    main()
  File "/usr/bin/avxjudge.py", line 315, in main
    do_file(args.filename)
  File "/usr/bin/avxjudge.py", line 231, in do_file
    print(function,"\t",ratio(sse_count/instructions),"\t", ratio(avx2_count / instructions), "\t", ratio(avx512_count/instructions), "\t", avx2_score,"\t", avx512_score)
NameError: name 'ratio' is not defined

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>