### PR TITLE
Use GNU Make as a way to do parallel runs of avxjudge.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,0 @@
-project(clr-avx-tools)
-cmake_minimum_required(VERSION 3.0)
-install(PROGRAMS
-        avxjudge.py
-        clr-avx2-move.pl
-        clr-python-avx2
-        clr-python-avx512
-        DESTINATION bin)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+prefix = $(DESTDIR)/usr
+bindir = $(prefix)/bin
+bin_PROGRAMS = \
+	clr-avx2-move.pl \
+	clr-python-avx2 \
+	clr-python-avx512
+
+datadir = $(prefix)/share/clr-avx-tools
+data_FILES = \
+	avxjudge.py \
+	avxjudge.make
+
+all:
+
+install:
+	install -d $(bindir) $(datadir)
+	install -m 755 -t $(bindir) $(bin_PROGRAMS)
+	install -m 644 -t $(datadir) $(data_FILES)

--- a/avxjudge.make
+++ b/avxjudge.make
@@ -1,0 +1,15 @@
+# -* makefile -*-
+MAKEFILE := $(lastword $(MAKEFILE_LIST))
+MAKEFILEDIR := $(dir $(MAKEFILE))
+
+.SUFFIXES:	# Remove implicit rules
+.PHONY: force
+force:
+
+# Don't try to update this makefile
+$(MAKEFILE):
+	:
+
+# For all other files, run avxjudge.py
+/%: force
+	python3 $(MAKEFILEDIR)/avxjudge.py $(ARGS) $@

--- a/clr-python-avx2
+++ b/clr-python-avx2
@@ -1,2 +1,2 @@
 #!/bin/sh
-python /usr/bin/avxjudge.py -q -2 $1
+exec make -kf /usr/share/clr-avx-tools/avxjudge.make ARGS="-q -2" "$@"

--- a/clr-python-avx512
+++ b/clr-python-avx512
@@ -1,2 +1,3 @@
 #!/bin/sh
-python /usr/bin/avxjudge.py -q -5 $1
+exec make -kf /usr/share/clr-avx-tools/avxjudge.make ARGS="-q -5" "$@"
+


### PR DESCRIPTION
The script is not really fast on big libraries, so parallelising the run
should sorten considerably the post-install procedures, especially on
build servers with a lot of cores.

Signed-off-by: Thiago Macieira <thiago.macieira@intel.com>