### PR TITLE
Return records for autospec inspection

### DIFF
--- a/avxjudge.py
+++ b/avxjudge.py
@@ -263,6 +263,7 @@ def do_file(filename: str, verbose:int, quiet:int, delete_type:str) -> None:
         except:
             None
 
+    return records
 
 def main():
     verbose = 0


### PR DESCRIPTION
This patch enable the use of records for autospec avxjudge detection of
SSE instructions

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>