### PR TITLE
Help to review these two commits to fix the duplicate counting issue

### DIFF
--- a/avxjudge.py
+++ b/avxjudge.py
@@ -146,8 +146,6 @@ def is_avx512(instruction:str, args:str) -> float:
             val = max(val, 1.0)
         else:
             val = max(val, 0.01)
-        if is_avx2(instruction, args) > 0:
-            val = max(val, is_avx2(instruction, args))
 
 
     return val
@@ -207,9 +205,12 @@ def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int)
         ins = match.group(1)
         arg = match.group(2)
 
-        sse_score = is_sse(ins, arg)
-        avx2_score = is_avx2(ins, arg)
         avx512_score = is_avx512(ins, arg)
+        if avx512_score <= 0:
+            avx2_score = is_avx2(ins, arg)
+        if avx2_score <= 0 and avx512_score <= 0:
+            sse_score = is_sse(ins, arg)
+
         records.function_record.instructions += 1
 
     match = re.search("\<([a-zA-Z0-9_@\.\-]+)\>\:", line)


### PR DESCRIPTION
Hi,
   There are two patches in this PR,
   The first one adds a '-d' command line option to avxjudge.py to debug the duplicate counting
issue of SSE&AVX2 or AVX2&AVX512, that was shown in opened issue.

  The second patch tries to fix the duplicate counting issue.
  Detail info is described in commit message.

  Please review and merge.

Thanks,
Ethan