### PR TITLE
Make sure first 4096 bytes factor into the sha256

### DIFF
--- a/elf-move.py
+++ b/elf-move.py
@@ -49,6 +49,7 @@ def process_install(args):
 
             with open(filepath, 'rb', buffering=0) as ifile:
                 blk = ifile.readinto(memv)
+                sha.update(memv[:blk])
                 elf = memv[:4] == b'\x7fELF'
                 while blk := ifile.readinto(memv):
                     sha.update(memv[:blk])


### PR DESCRIPTION
The first 4096 bytes were not being accounted for, resulting in any ELF
content with size <= 4096 having the same sha256.