### PR TITLE
avxjudge: fix function tracking issues

### DIFF
--- a/avxjudge.py
+++ b/avxjudge.py
@@ -210,6 +210,18 @@ def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int)
     global avx2_avx512_duplicate_cnt
     global debug
 
+    match = re.search("^$", line)
+    if match:
+        if records.function_record.instructions > 0 and verbose > 0:
+            print()
+            print_function_summary(records)
+        if verbose > 0:
+            print()
+        if records.function_record.instructions > 0:
+            records.finalize_function_attrs()
+            records.function_record = FunctionRecord()
+        return
+
     match = re.search("^(.*)\#.*", line)
     if match:
         line = match.group(1)
@@ -230,11 +242,6 @@ def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int)
     match = re.search("\<([a-zA-Z0-9_@\.\-]+)\>\:", line)
     if match:
         records.function_record.name = match.group(1)
-        if records.function_record.instructions > 0 and verbose > 0:
-            print_function_summary(records)
-        if records.function_record.instructions > 0:
-            records.finalize_function_attrs()
-            records.function_record = FunctionRecord()
 
     if sse_score >= 0.0:
         sse_str = str(sse_score)

--- a/avxjudge.py
+++ b/avxjudge.py
@@ -239,7 +239,7 @@ def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int)
 
         records.function_record.instructions += 1
 
-    match = re.search("\<([a-zA-Z0-9_@\.\-]+)\>\:", line)
+    match = re.search(r'^[0-9a-f]+ <(.+)>:$', line)
     if match:
         records.function_record.name = match.group(1)
 

--- a/avxjudge.py
+++ b/avxjudge.py
@@ -189,6 +189,15 @@ def print_top_functions(records:RecordKeeper) -> None:
 sse_avx2_duplicate_cnt = 0
 avx2_avx512_duplicate_cnt = 0
 
+def print_function_summary(records):
+    print(records.function_record.name,
+          "\t", ratio(records.function_record.counts["sse"] / records.function_record.instructions),
+          "\t", ratio(records.function_record.counts["avx2"] / records.function_record.instructions),
+          "\t", ratio(records.function_record.counts["avx512"] / records.function_record.instructions),
+          "\t", records.function_record.scores["sse"],
+          "\t", records.function_record.scores["avx2"],
+          "\t", records.function_record.scores["avx512"])
+
 def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int) -> None:
     sse_score = -1.0
     avx2_score = -1.0
@@ -222,13 +231,7 @@ def process_objdump_line(records:RecordKeeper, line:str, verbose:int, quiet:int)
     if match:
         records.function_record.name = match.group(1)
         if records.function_record.instructions > 0 and verbose > 0:
-            print(records.function_record.name,
-                  "\t", ratio(records.function_record.counts["sse"] / records.function_record.instructions),
-                  "\t", ratio(records.function_record.counts["avx2"] / records.function_record.instructions),
-                  "\t", ratio(records.function_record.counts["avx512"] / records.function_record.instructions),
-                  "\t", records.function_record.scores["sse"],
-                  "\t", records.function_record.scores["avx2"],
-                  "\t", records.function_record.scores["avx512"])
+            print_function_summary(records)
         if records.function_record.instructions > 0:
             records.finalize_function_attrs()
             records.function_record = FunctionRecord()


### PR DESCRIPTION
After analyzing output from `avxjudge.py -v ...` in more detail, I discovered some issues it had with parsing `objdump -d` output:

- An ordering issue in the parsing function led to an off-by-one issue of sorts for instruction count / function correspondence.
- The function name matcher regex was too restrictive, at least for Golang binaries, which are observed to contain function names with many other characters.

This PR fixes both of these issues.